### PR TITLE
Fixed default white color on iOS 14 and above

### DIFF
--- a/UseDesk/Classes/UDMessageCellNode.swift
+++ b/UseDesk/Classes/UDMessageCellNode.swift
@@ -37,6 +37,7 @@ class UDMessageCellNode: ASCellNode {
         bubbleImage = bubbleImage.stretchableImage(withLeftCapWidth: 23, topCapHeight: 16).withRenderingMode(.alwaysTemplate)
         bubbleImageNode.image = bubbleImage
         bubbleImageNode.imageModificationBlock = ASImageNodeTintColorModificationBlock(message.incoming != false ? bubbleStyle.bubbleColorIncoming : bubbleStyle.bubbleColorOutgoing)
+        backgroundColor = .clear
         
         //avatar and time
         if isPictureOrVideoType {


### PR DESCRIPTION
Since iOS 14 system adds default white background if backgroundColor of the cell is nil.

Referring to this issue in Texture: https://github.com/TextureGroup/Texture/issues/2009#issuecomment-877094879

Steps to reproduce:

1. Open Example project
2. Open UDStartViewController.swift
3. Add ChatStyle with custom backgroundColor
```swift
let style = ChatStyle(backgroundColor: .green, backgroundColorLoaderView: nil, alphaLoaderView: 0.9)

usedesk.configurationStyle = ConfigurationStyle(chatStyle: style, baseStyle: BaseStyle(isNeedChat: isNeedChatSwitch.isOn), baseArticleStyle: BaseArticleStyle(isNeedReview: isNeedReviewSwitch.isOn))
```

Result: 
Cell has white background.

![IMG_0067](https://user-images.githubusercontent.com/17787045/126639554-175b9418-a972-4d83-afd1-827b37aa2311.jpg)


