### PR TITLE
Support xcodeproj and xcworkspace generation

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -1,11 +1,9 @@
 project 'UseDesk_SDK_Swift.xcodeproj'
 
 # Uncomment the next line to define a global platform for your project
-platform :ios, '15.0'
+platform :ios, '11.0'
 
 target 'UseDesk_SDK_Swift' do
-  # Comment the next line if you don't want to use dynamic frameworks
-  use_frameworks!
 
   # Pods for UseDesk_SDK_Swift
   pod 'Socket.IO-Client-Swift', '~> 16'

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,27 @@
+project 'UseDesk_SDK_Swift.xcodeproj'
+
+# Uncomment the next line to define a global platform for your project
+platform :ios, '15.0'
+
+target 'UseDesk_SDK_Swift' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for UseDesk_SDK_Swift
+  pod 'Socket.IO-Client-Swift', '~> 16'
+  pod 'Alamofire', '~> 5'
+  pod 'MarkdownKit'
+  pod 'Texture'
+  pod 'ReachabilitySwift'
+  pod 'SwiftSoup'
+
+  post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name == 'Socket.IO-Client-Swift' then
+      target.build_configurations.each do |config|
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'
+      end
+    end
+  end
+end
+end

--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ import UseDesk
 
 The SDK implementation for installation using SPM is placed in a separate [repository](https://github.com/usedesk/UseDeskSPM). Please note that GUI is not available when installing with SPM. 
 
+You may use an option with binary target in the SPM configuration.
+1. Install xcodegen:
+    - `brew install xcodegen`
+2. Generate `xcodeproj`:
+    - `xcodegen generate`
+3. Install pods
+    - `pod install`
+4. Build xcframework:
+```sh
+xcodebuild archive \
+    -workspace UseDesk_SDK_Swift.xcworkspace \
+    -scheme UseDesk_SDK_Swift \
+    -destination="generic/platform=iOS" \
+    -sdk iphoneos \
+    -archivePath "build/UseDesk_SDK_Swift-ios" \
+    SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+&& \
+xcodebuild archive \
+    -workspace UseDesk_SDK_Swift.xcworkspace \
+    -scheme UseDesk_SDK_Swift \
+    -destination="simulator" \
+    -sdk iphonesimulator \
+    -archivePath "build/UseDesk_SDK_Swift-simulator" \
+    SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+
+xcodebuild -create-xcframework \
+    -archive build/UseDesk_SDK_Swift-ios.xcarchive \
+    -archive build/UseDesk_SDK_Swift-simulator.xcarchive \
+    -framework UseDesk_SDK_Swift.framework \
+    -output build/UseDesk_SDK_Swift.xcframework
+```
+4. Archive `xcframework`:
+    - `cd build && zip -r UseDesk_SDK_Swift.zip UseDesk_SDK_Swift/*`
+
+5. Use binary target in `Package.swift`:
+```Swift
+.binaryTarget(
+    name: "UseDesk_SDK_Swift",
+    path: "path/to/some/UseDesk_SDK_Swift.zip",
+    checksum: "The checksum of the ZIP archive that contains the XCFramework."
+),
+```
 ## Initializing a Chat or Knowledge Base with Chat using the GUI
 
 ### Parameters used in the configuration SDK with GUI

--- a/UseDesk_SDK_Swift-UseDesk-Bridging-Header.h
+++ b/UseDesk_SDK_Swift-UseDesk-Bridging-Header.h
@@ -2,3 +2,6 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import <UIKit/UIKit.h>
+#import <MapKit/MapKit.h>
+#import <AVFoundation/AVFoundation.h>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,44 @@
+name: UseDesk_SDK_Swift
+targets:
+  UseDesk_SDK_Swift:
+    supportedDestinations: [iOS]
+    platform: iOS
+    deploymentTarget: 12.0
+    bundleIdentifier: ru.usedesk
+    type: framework
+    sources:
+      - path: UseDesk/Classes
+        excludes:
+        - ".gitkeep"
+        - ".gitignore"
+      - path: UseDesk/Assets
+        excludes:
+        - ".gitkeep"
+        - ".gitignore"
+      - path: Core
+        excludes:
+        - ".gitkeep"
+        - ".gitignore"
+      - path: Info.plist
+      - path: PrivacyInfo.xcprivacy
+    dependencies:
+      - sdk: UIKit.framework
+      - sdk: MapKit.framework
+      - sdk: AVFoundation.framework
+    settings:
+      destination: UseDesk_SDK_Swift
+      MARKETING_VERSION: 3.4.13
+      CODE_SIGN_STYLE: Manual
+      INFOPLIST_FILE: Info.plist
+      IPHONEOS_DEPLOYMENT_TARGET: 12.0
+      CURRENT_PROJECT_VERSION: 3.4.13
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: "ru.usedesk"
+          SWIFT_OBJC_BRIDGING_HEADER: UseDesk_SDK_Swift-UseDesk-Bridging-Header.h
+          DEBUG_MODE: YES
+        Release:
+          PRODUCT_BUNDLE_IDENTIFIER: "ru.usedesk"
+          SWIFT_OBJC_BRIDGING_HEADER: UseDesk_SDK_Swift-UseDesk-Bridging-Header.h
+          DEBUG_MODE: NO
+     


### PR DESCRIPTION
Add `project.yml` configuration file in order to support generation of the `xcodeproj`. Add `Podfile` in order to install the dependencies and generate `xcworspace`. Add the headers to the bridging header file in order to avoid explicit import in the source code files.