### PR TITLE
Fix the "ITMS-91105: Invalid API category declaration" submission error.

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -10,7 +10,7 @@
 				<string>CA92.1</string>
 			</array>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>User Defaults</string>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>


### PR DESCRIPTION
The `<string>User Defaults</string` value for the NSPrivacyAccessedAPIType key in the privacy manifest file causes a warning **ITMS-91105: Invalid API category declaration** due to the app's submission process. The warning turns out into an error within a few weeks. 
Regarding to the [official documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) it has to be `NSPrivacyAccessedAPICategoryUserDefaults`.
The error text is below:
> Hello,

> We noticed one or more issues with a recent submission for App Store review for the following app

> Although submission for App Store review was successful, you may want to correct the following issues in your next submission for App Store review. Once you've corrected the issues, upload a new binary to App Store Connect.

> ITMS-91105: Invalid API category declaration - The PrivacyInfo.xcprivacy file at the “UseDeskSwift_UseDeskSwift.bundle/PrivacyInfo.xcprivacy” path contains “User Defaults” as the value for a NSPrivacyAccessedAPIType key, which is invalid. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Values for NSPrivacyAccessedAPIType keys in any privacy manifest must be valid API categories. For more details about this policy, including a list of required reason APIs and approved reasons for usage, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.

> Apple Developer Relations
---

Значение `<string>User Defaults</string` для ключа `NSPrivacyAccessedAPIType` в privacy manifest файле, порождает письмо с предупреждением **ITMS-91105: Invalid API category declaration** при отправке приложения на ревью. Через несколько недель предупреждение превратится в ошибку. 
Согласно [документации](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) значение должно быть `NSPrivacyAccessedAPICategoryUserDefaults`.

Текст письма:
> Hello,

> We noticed one or more issues with a recent submission for App Store review for the following app

> Although submission for App Store review was successful, you may want to correct the following issues in your next submission for App Store review. Once you've corrected the issues, upload a new binary to App Store Connect.

> ITMS-91105: Invalid API category declaration - The PrivacyInfo.xcprivacy file at the “UseDeskSwift_UseDeskSwift.bundle/PrivacyInfo.xcprivacy” path contains “User Defaults” as the value for a NSPrivacyAccessedAPIType key, which is invalid. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Values for NSPrivacyAccessedAPIType keys in any privacy manifest must be valid API categories. For more details about this policy, including a list of required reason APIs and approved reasons for usage, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.

> Apple Developer Relations

---

<img width="785" alt="Снимок экрана 2024-10-02 в 15 35 02" src="https://github.com/user-attachments/assets/bd7c3737-3e75-4e9b-bf24-0c1d1454e91a">
